### PR TITLE
isReady is set back to true when action completes

### DIFF
--- a/epic.js
+++ b/epic.js
@@ -164,6 +164,7 @@ const createEpics = ({ actionTypes, actionCreators, service }) => {
 
           return Rx.Observable.of(actionCreators.start(cid, { service, method, args }))
             .concat(requestAction$)
+            .concat(Rx.Observable.of(actionCreators.ready(cid)))
             .concat(Rx.Observable.of(actionCreators.complete(cid)))
             .catch(err => Rx.Observable.of(actionCreators.error(cid, err)))
             .takeUntil(cancelAction$)

--- a/updater.js
+++ b/updater.js
@@ -84,7 +84,6 @@ function createRequestUpdater (actionTypes) {
     return pipe(
       assocPath([cid, 'result'], result),
       assocPath([cid, 'error'], error),
-      assocPath([cid, 'isReady'], true)
     )
   }
 

--- a/updater.js
+++ b/updater.js
@@ -83,7 +83,8 @@ function createRequestUpdater (actionTypes) {
   function handleComplete ({ cid, result, error }) {
     return pipe(
       assocPath([cid, 'result'], result),
-      assocPath([cid, 'error'], error)
+      assocPath([cid, 'error'], error),
+      assocPath([cid, 'isReady'], true)
     )
   }
 


### PR DESCRIPTION
This change introduces changing the `onReady` state to true when an action completes (error or successful).

This would mean:
`onReady === true && error === null` - success
`onReady === true && error !== null` - error

Needed for https://github.com/root-systems/cobuy/pull/139